### PR TITLE
Fix a calculation bug when there're blanks around names

### DIFF
--- a/evaluate_lineup.js
+++ b/evaluate_lineup.js
@@ -114,9 +114,9 @@ function parseAllPlayersFromJson(rawPlayers) {
         let current = new Player()
 
         current.number = player.shirtNumber
-        current.name = player.firstName + " " + player.lastName
+        current.name = player.firstName.trim() + " " + player.lastName.trim()
         current.age = player.ageYear
-        current.pos = player.favouritePosition
+        current.pos = player.favouritePosition.trim()
 
         if (current.pos === 'GK') {
             // skip Goalkeeper


### PR DESCRIPTION
If there are leading or trailling blanks around players' names, the script will fail to find counterpart player objects against names from lineup data.